### PR TITLE
feat: add health, readiness, and metrics endpoints

### DIFF
--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -37,7 +37,6 @@ func TestServerRun(t *testing.T) {
 		"kill": {
 			operations: func(s *promserver) { close(s.killChannel) },
 			expectedLogEntries: []string{
-				"server failed",
 				"flushing all data files",
 				"shutting down",
 			},

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace github.com/xitongsys/parquet-go => github.com/drmorr0/parquet-go v1.7.0
 
 require (
 	github.com/jonboulle/clockwork v0.4.0
+	github.com/prometheus/client_golang v1.18.0
 	github.com/prometheus/common v0.47.0
 	github.com/prometheus/prometheus v0.49.1
 	github.com/samber/lo v1.39.0
@@ -84,7 +85,6 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.15 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.18.0 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common/sigv4 v0.1.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect


### PR DESCRIPTION
- Add /health endpoint for liveness probes (returns uptime, version)
- Add /ready endpoint for readiness probes (returns active writers count)
- Add /metrics endpoint for Prometheus metrics export
- Add metrics: requests_total, samples_received, timeseries_received, active_writers, request_duration_seconds
- Improve graceful shutdown handling (don't log ErrServerClosed)
- Update tests to reflect new shutdown behavior

## Related Links
<!-- include a link to the issue(s) this resolves and/or any related design docs -->
- TODO

## Description and Rationale
<!-- a short bulleted list of the high-level changes you made, along with the reason why; if any change needs a more
detailed explanation, feel free to break this up into subsections -->
- Change 1: Why we made the change

## How
<!-- if the changes are not obvious/straightforward, explain how you approached the problem -->
- TODO

## Test Steps
<!-- how did you test your changes? ideally with enough detail that someone else can replicate the tests -->
- TODO

## Other Notes
<!-- any other notes/comments/feedback/suggestions that will help your reviewers out -->
- TODO

<!-- This PR template taken (and slightly modified) from https://ashleemboyer.com/blog/pull-request-template/#the-template -->
